### PR TITLE
Add a Dockerfile to support silq in a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM dlang2/dmd-ubuntu
+LABEL maintainer="Silq Team"
+LABEL description="Silq is a high-level programming language for quantum computing with a strong static type system."
+
+RUN apt update
+RUN apt install -y git ldc
+RUN git clone https://github.com/eth-sri/silq.git /silq
+WORKDIR /silq
+RUN ./dependencies-release.sh && ./build-release.sh
+
+CMD ./silq --help


### PR DESCRIPTION
This PR adds a Silq Dockerfile to support running Silq experiments inside of a container. It doesn't add anything to the overhead of the codebase, and clones the latest from this repository when built (i.e., is not version-pinned, but will always be up-to-date).

I have been using this for a little while and saw #24, and thought I'd contribute. Feel free to close if you prefer not to have this in the repository! 